### PR TITLE
[SDK 155] Deprecate Kovan for Goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ public class Main {
 
     public static void main(String... args) {
         // Builds the project client to run on the Goerli test network.
-        // See: https://goerli.cloud.enjin.io/ to sign up for the test network.
+        // See: https://goerli.cloud.enjin.io to sign up for the test network.
         ProjectClient client = new ProjectClient(EnjinHosts.GOERLI);
 
         // Creates the request to authenticate the client.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create blockchain video games and applications using the Java programming langua
 
 [Learn more](https://enjin.io/) about the Enjin blockchain platform.
 
-Sign up to Enjin Cloud: [Kovan (Testnet)](https://kovan.cloud.enjin.io/),
+Sign up to Enjin Cloud: [Goerli (Testnet)](https://goerli.cloud.enjin.io/),
 [Mainnet (Production)](https://cloud.enjin.io/) or [JumpNet](https://jumpnet.cloud.enjin.io/).
 
 ### Resources
@@ -79,9 +79,9 @@ import com.enjin.sdk.schemas.project.queries.AuthProject;
 public class Main {
 
     public static void main(String... args) {
-        // Builds the project client to run on the Kovan test network.
-        // See: https://kovan.cloud.enjin.io to sign up for the test network.
-        ProjectClient client = new ProjectClient(EnjinHosts.KOVAN);
+        // Builds the project client to run on the Goerli test network.
+        // See: https://goerli.cloud.enjin.io/ to sign up for the test network.
+        ProjectClient client = new ProjectClient(EnjinHosts.GOERLI);
 
         // Creates the request to authenticate the client.
         // Replace the appropriate strings with the project's UUID and secret.

--- a/sdk/src/main/java/com/enjin/sdk/EnjinHosts.java
+++ b/sdk/src/main/java/com/enjin/sdk/EnjinHosts.java
@@ -16,22 +16,30 @@
 package com.enjin.sdk;
 
 /**
- * The network hosts used by the Enjin Cloud.
+ * The network hosts used by the Enjin Platform.
  */
 public final class EnjinHosts {
 
     /**
-     * The URL for the main Enjin Cloud.
+     * The URL for the Enjin Platform on the main network.
      */
     public static final String MAIN_NET = "https://cloud.enjin.io/";
 
     /**
-     * The URL for the kovan Enjin Cloud.
+     * The URL for the Enjin Platform on the Goerli test network.
      */
+    public static final String GOERLI = "https://goerli.cloud.enjin.io/";
+
+    /**
+     * The URL for the Enjin Platform on the Kovan test network.
+     *
+     * @deprecated This host may no longer be supported. Use the {@link EnjinHosts#GOERLI} host.
+     */
+    @Deprecated
     public static final String KOVAN = "https://kovan.cloud.enjin.io/";
 
     /**
-     * The URL for the JumpNet network.
+     * The URL for the Enjin Platform on the JumpNet network.
      */
     public static final String JUMP_NET = "https://jumpnet.cloud.enjin.io/";
 

--- a/sdk/src/main/java/com/enjin/sdk/EnjinHosts.java
+++ b/sdk/src/main/java/com/enjin/sdk/EnjinHosts.java
@@ -31,14 +31,6 @@ public final class EnjinHosts {
     public static final String GOERLI = "https://goerli.cloud.enjin.io/";
 
     /**
-     * The URL for the Enjin Platform on the Kovan test network.
-     *
-     * @deprecated This host may no longer be supported. Use the {@link EnjinHosts#GOERLI} host.
-     */
-    @Deprecated
-    public static final String KOVAN = "https://kovan.cloud.enjin.io/";
-
-    /**
      * The URL for the Enjin Platform on the JumpNet network.
      */
     public static final String JUMP_NET = "https://jumpnet.cloud.enjin.io/";

--- a/sdk/src/test/java/com/enjin/sdk/events/channels/WalletChannelTest.java
+++ b/sdk/src/test/java/com/enjin/sdk/events/channels/WalletChannelTest.java
@@ -22,14 +22,14 @@ import org.junit.jupiter.api.Test;
 
 class WalletChannelTest {
 
-    private static final String PLATFORM_NAME = "test";
+    private static final String NETWORK_NAME = "test";
 
     @Test
-    void channel_Kovan_ReturnCorrectString() {
+    void channel_ReturnCorrectString() {
         // Arrange
         final String expected = "enjincloud.test.wallet.0";
         final String wallet = "0";
-        final Platform platform = PlatformUtils.createFakePlatform(PLATFORM_NAME);
+        final Platform platform = PlatformUtils.createFakePlatform(NETWORK_NAME);
         final Channel channel = new WalletChannel(platform, wallet);
 
         // Act


### PR DESCRIPTION
- Added Goerli host to `EnjinHosts`
- Deprecated Kovan host
- Updated `README.md` to use Goerli instead of Kovan