### PR TITLE
[SDK 154] Deprecate Kovan for Goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Create blockchain video games and applications using the Java programming langua
 
 [Learn more](https://enjin.io/) about the Enjin blockchain platform.
 
-Sign up to Enjin Cloud: [Kovan (Testnet)](https://kovan.cloud.enjin.io/),
+Sign up to Enjin Cloud: [Goerli (Testnet)](https://goerli.cloud.enjin.io/),
 [Mainnet (Production)](https://cloud.enjin.io/) or [JumpNet](https://jumpnet.cloud.enjin.io/).
 
 ### Resources

--- a/examples/platformer-server/src/main/java/com/enjin/platformer/server/PlatformerServer.java
+++ b/examples/platformer-server/src/main/java/com/enjin/platformer/server/PlatformerServer.java
@@ -50,7 +50,7 @@ public class PlatformerServer extends WebSocketServer {
         super(config.getAddress());
         this.config = config;
         this.processor = new PacketProcessor();
-        this.sdk = new TrustedPlatformClientBuilder().baseUrl(TrustedPlatformClientBuilder.KOVAN)
+        this.sdk = new TrustedPlatformClientBuilder().baseUrl(TrustedPlatformClientBuilder.GOERLI)
                                                      .httpLogLevel(Level.BODY)
                                                      .build();
         this.updateTimer = new Timer();

--- a/sdk/src/main/java/com/enjin/sdk/TrustedPlatformClientBuilder.java
+++ b/sdk/src/main/java/com/enjin/sdk/TrustedPlatformClientBuilder.java
@@ -15,12 +15,26 @@ import java.util.concurrent.TimeUnit;
 public class TrustedPlatformClientBuilder {
 
     /**
-     * The url for the main Enjin cloud.
+     * The URL for the Enjin Platform on the main network.
      */
     public static final HttpUrl MAIN_NET = HttpUrl.get("https://cloud.enjin.io/");
+
     /**
-     * The url for the kovan Enjin cloud.
+     * The URL for the Enjin Platform on the JumpNet network.
      */
+    public static final String JUMP_NET = "https://jumpnet.cloud.enjin.io/";
+
+    /**
+     * The URL for the Enjin Platform on the Goerli test network.
+     */
+    public static final HttpUrl GOERLI = HttpUrl.get("https://goerli.cloud.enjin.io/");
+
+    /**
+     * The URL for the Enjin Platform on the Kovan test network.
+     *
+     * @deprecated This host may no longer be supported. Use the {@link TrustedPlatformClientBuilder#GOERLI} host.
+     */
+    @Deprecated
     public static final HttpUrl KOVAN = HttpUrl.get("https://kovan.cloud.enjin.io/");
 
     /**


### PR DESCRIPTION
- Added Goerli host to `TrustedPlatformClientBuilder`
- Added JumpNet host to `TrustedPlatformClientBuilder`
- Deprecated Kovan host
- Updated `README.md` to use Goerli instead of Kovan